### PR TITLE
Better creation with statuses

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,8 +77,7 @@
     "winston": "2.3.1",
     "winston-daily-rotate-file": "1.4.6",
     "winston-graylog2": "0.6.0",
-    "winston-loggly": "1.3.1",
-    "snyk": "^1.33.0"
+    "winston-loggly": "1.3.1"
   },
   "devDependencies": {
     "chai": "4.0.1",
@@ -99,6 +98,7 @@
     "proxyquire": "1.8.0",
     "sinon": "2.3.2",
     "sinon-chai": "2.10.0",
+    "snyk": "1.33.0",
     "supertest": "3.0.0",
     "swagger-ui": "3.0.13"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
   "name": "node-api-seed",
   "title": "Node Api Seed",
-  "version": "0.0.0",
+  "version": "0.0.1",
+  "engines": {
+    "node": ">=6.10.0"
+  },
   "deploymentDate": "2016-11-09T19:15:04.309Z",
   "description": "The seed for pretty much any api I write in node.js",
   "main": "index.js",

--- a/src/crud/create.js
+++ b/src/crud/create.js
@@ -90,7 +90,9 @@ function description(metadata) {
         responses: {
             '201': {
                 description:
-                    'Informs the caller that the ' + metadata.title.toLowerCase() + ' was successfully created.',
+                    'Informs the caller that the ' +
+                        metadata.title.toLowerCase() +
+                        ' was successfully created.',
                 commonHeaders: [correlationIdOptions.resHeader],
                 model: metadata.schemas.output.name
             }
@@ -156,13 +158,21 @@ function getFromReqObject(
         if (_.isArray(value)) {
             ensureMapIsString(value[0]);
             if (value.length > 2) {
-                throw new Error(util.format('Too many items in array, should be at most 2. %j', value));
+                throw new Error(
+                    util.format('Too many items in array, should be at most 2. %j', value)
+                );
             }
             data[key] = getValue(req, value[0], value[1], disallowedSuffixList, allowedPrefixList);
             return;
         }
         if (_.isObject(value)) {
-            data[key] = getFromReqObject(value, req, depth + 1, disallowedSuffixList, allowedPrefixList);
+            data[key] = getFromReqObject(
+                value,
+                req,
+                depth + 1,
+                disallowedSuffixList,
+                allowedPrefixList
+            );
             return;
         }
         ensureMapIsString(value);
@@ -199,7 +209,12 @@ function setOwnerIfApplicable(metadata) {
             req.body.owner = _.get(req, ownership.setOwnerExpression);
             if (!req.body.owner) {
                 return next(
-                    boom.badRequest(util.format('Owner from expression "%s" was blank', ownership.setOwnerExpression))
+                    boom.badRequest(
+                        util.format(
+                            'Owner from expression "%s" was blank',
+                            ownership.setOwnerExpression
+                        )
+                    )
                 );
             }
         } else {

--- a/src/crud/create.js
+++ b/src/crud/create.js
@@ -110,7 +110,7 @@ function setStatusIfApplicable(metadata) {
         req.body.statusLog = [
             {
                 status: req.body.status,
-                data: getData(statusToSet.initialData, req),
+                data: addCreateRoute.getData(statusToSet.initialData, req),
                 statusDate: req.body.statusDate
             }
         ];

--- a/src/crud/create.js
+++ b/src/crud/create.js
@@ -110,6 +110,7 @@ function setStatusIfApplicable(metadata) {
         req.body.statusLog = [
             {
                 status: req.body.status,
+                //we use 'addCreateRoute.' here to allow stubbing in the unit tests
                 data: addCreateRoute.getData(statusToSet.initialData, req),
                 statusDate: req.body.statusDate
             }
@@ -122,6 +123,7 @@ function getData(rules, req) {
     if (!rules) {
         return;
     }
+    //we use 'addCreateRoute.' here to allow stubbing in the unit tests
     const fromReq = addCreateRoute.getFromReqObject(rules.fromReq, req);
     return _.merge({}, rules.static, fromReq);
 }
@@ -146,6 +148,9 @@ function getFromReqObject(map, req, depth = 0) {
         if (_.isObject(value)) {
             data[key] = getFromReqObject(value, req, depth + 1);
             return;
+        }
+        if (!_.isString(value)) {
+            throw new Error(util.format('Invalid map value, must be a string : \n%j\n', value));
         }
         data[key] = _.get(req, value);
     });

--- a/src/crud/create.js
+++ b/src/crud/create.js
@@ -147,6 +147,9 @@ function getFromReqObject(map, req, depth = 0) {
         const value = map[key];
         if (_.isArray(value)) {
             ensureMapIsString(value[0]);
+            if (value.length > 2) {
+                throw new Error(util.format('Too many items in array, should be at most 2. %j', value));
+            }
             data[key] = _.get(req, value[0], value[1]);
             return;
         }
@@ -159,7 +162,7 @@ function getFromReqObject(map, req, depth = 0) {
     });
     return data;
 }
-function ensureMapIsString(map){
+function ensureMapIsString(map) {
     if (!_.isString(map)) {
         throw new Error(util.format('Invalid map value, must be a string : \n%j\n', map));
     }

--- a/src/crud/create.js
+++ b/src/crud/create.js
@@ -129,8 +129,15 @@ function getData(rules, req) {
 }
 
 const defaultDisallowedSuffixList = ['password', 'passwordHash', 'passwordSalt'];
+const defaultAllowedPrefixList = ['user', 'process', 'body', 'params', 'query'];
 const maxDepth = 10;
-function getFromReqObject(map, req, depth = 0, disallowedSuffixList = defaultDisallowedSuffixList) {
+function getFromReqObject(
+    map,
+    req,
+    depth = 0,
+    disallowedSuffixList = defaultDisallowedSuffixList,
+    allowedPrefixList = defaultAllowedPrefixList
+) {
     if (!map) {
         return;
     }
@@ -151,23 +158,27 @@ function getFromReqObject(map, req, depth = 0, disallowedSuffixList = defaultDis
             if (value.length > 2) {
                 throw new Error(util.format('Too many items in array, should be at most 2. %j', value));
             }
-            data[key] = getValue(req, value[0], value[1], disallowedSuffixList);
+            data[key] = getValue(req, value[0], value[1], disallowedSuffixList, allowedPrefixList);
             return;
         }
         if (_.isObject(value)) {
-            data[key] = getFromReqObject(value, req, depth + 1);
+            data[key] = getFromReqObject(value, req, depth + 1, disallowedSuffixList, allowedPrefixList);
             return;
         }
         ensureMapIsString(value);
-        data[key] = getValue(req, value, undefined, disallowedSuffixList);
+        data[key] = getValue(req, value, undefined, disallowedSuffixList, allowedPrefixList);
     });
     return data;
 }
 
-function getValue(req, map, defaultValue, disallowedSuffixList) {
+function getValue(req, map, defaultValue, disallowedSuffixList, allowedPrefixList) {
     const disallowed = disallowedSuffixList.find(suffix => map.endsWith(suffix));
     if (disallowed) {
         throw new Error('Map is not allowed to end with ' + disallowed);
+    }
+    const allowed = allowedPrefixList.find(prefix => map.startsWith(prefix));
+    if (!allowed) {
+        throw new Error(util.format('Map must start with one of %j', allowedPrefixList));
     }
     return _.get(req, map, defaultValue);
 }

--- a/src/crud/create.js
+++ b/src/crud/create.js
@@ -122,7 +122,7 @@ function getData(rules, req) {
     if (!rules) {
         return;
     }
-    const fromReq = getFromReqObject(rules.fromReq, req);
+    const fromReq = addCreateRoute.getFromReqObject(rules.fromReq, req);
     return _.merge({}, rules.static, fromReq);
 }
 

--- a/src/crud/create.js
+++ b/src/crud/create.js
@@ -90,9 +90,7 @@ function description(metadata) {
         responses: {
             '201': {
                 description:
-                    'Informs the caller that the ' +
-                        metadata.title.toLowerCase() +
-                        ' was successfully created.',
+                    'Informs the caller that the ' + metadata.title.toLowerCase() + ' was successfully created.',
                 commonHeaders: [correlationIdOptions.resHeader],
                 model: metadata.schemas.output.name
             }
@@ -136,8 +134,9 @@ function getFromReqObject(map, req, depth = 0) {
     if (depth > maxDepth) {
         throw new Error(
             util.format(
-                'Circular reference detected in map object after maximum depth (%s) reached',
-                maxDepth
+                'Circular reference detected in map object after maximum depth (%s) reached. Partial map\n%j\n',
+                maxDepth,
+                util.inspect(map, true, maxDepth)
             )
         );
     }
@@ -163,12 +162,7 @@ function setOwnerIfApplicable(metadata) {
             req.body.owner = _.get(req, ownership.setOwnerExpression);
             if (!req.body.owner) {
                 return next(
-                    boom.badRequest(
-                        util.format(
-                            'Owner from expression "%s" was blank',
-                            ownership.setOwnerExpression
-                        )
-                    )
+                    boom.badRequest(util.format('Owner from expression "%s" was blank', ownership.setOwnerExpression))
                 );
             }
         } else {

--- a/src/crud/create.js
+++ b/src/crud/create.js
@@ -27,6 +27,7 @@ addCreateRoute.sendCreateResult = sendCreateResult;
 addCreateRoute.description = description;
 addCreateRoute.setStatusIfApplicable = setStatusIfApplicable;
 addCreateRoute.setOwnerIfApplicable = setOwnerIfApplicable;
+addCreateRoute.getFromReqObject = getFromReqObject;
 
 module.exports = addCreateRoute;
 
@@ -105,17 +106,23 @@ function setStatusIfApplicable(metadata) {
         const statusToSet = statuses[0];
         req.body.status = statusToSet.name;
         req.body.statusDate = moment.utc().toDate();
-        const logEntry = {
-            status: req.body.status,
-            statusDate: req.body.statusDate
-        };
-        if (statusToSet.initialData) {
-            const fromReq = getFromReqObject(statusToSet.initialData.fromReq, req);
-            logEntry.data = _.merge({}, statusToSet.initialData.static, fromReq);
-        }
-        req.body.statusLog = [logEntry];
+        req.body.statusLog = [
+            {
+                status: req.body.status,
+                data: getData(statusToSet.initialData, req),
+                statusDate: req.body.statusDate
+            }
+        ];
         return next();
     };
+}
+
+function getData(rules, req) {
+    if (!rules) {
+        return;
+    }
+    const fromReq = getFromReqObject(rules.fromReq, req);
+    return _.merge({}, rules.static, fromReq);
 }
 
 function getFromReqObject(map, req) {

--- a/src/crud/create.js
+++ b/src/crud/create.js
@@ -145,6 +145,10 @@ function getFromReqObject(map, req, depth = 0) {
     const data = {};
     Object.keys(map).forEach(function(key) {
         const value = map[key];
+        if (_.isArray(value)) {
+            data[key] = _.get(req, value[0], value[1]);
+            return;
+        }
         if (_.isObject(value)) {
             data[key] = getFromReqObject(value, req, depth + 1);
             return;

--- a/src/crud/create.js
+++ b/src/crud/create.js
@@ -22,8 +22,12 @@ function addCreateRoute(router, crudMiddleware, maps) {
         .describe(router.metadata.creationDescription || description(router.metadata));
     return router;
 }
+addCreateRoute.getSteps = getSteps;
+addCreateRoute.sendCreateResult = sendCreateResult;
+addCreateRoute.description = description;
 addCreateRoute.setStatusIfApplicable = setStatusIfApplicable;
 addCreateRoute.setOwnerIfApplicable = setOwnerIfApplicable;
+
 module.exports = addCreateRoute;
 
 function getSteps(router, crudMiddleware, maps) {

--- a/src/crud/create.js
+++ b/src/crud/create.js
@@ -146,6 +146,7 @@ function getFromReqObject(map, req, depth = 0) {
     Object.keys(map).forEach(function(key) {
         const value = map[key];
         if (_.isArray(value)) {
+            ensureMapIsString(value[0]);
             data[key] = _.get(req, value[0], value[1]);
             return;
         }
@@ -153,12 +154,15 @@ function getFromReqObject(map, req, depth = 0) {
             data[key] = getFromReqObject(value, req, depth + 1);
             return;
         }
-        if (!_.isString(value)) {
-            throw new Error(util.format('Invalid map value, must be a string : \n%j\n', value));
-        }
+        ensureMapIsString(value);
         data[key] = _.get(req, value);
     });
     return data;
+}
+function ensureMapIsString(map){
+    if (!_.isString(map)) {
+        throw new Error(util.format('Invalid map value, must be a string : \n%j\n', map));
+    }
 }
 
 function setOwnerIfApplicable(metadata) {

--- a/src/crud/create.js
+++ b/src/crud/create.js
@@ -28,6 +28,7 @@ addCreateRoute.description = description;
 addCreateRoute.setStatusIfApplicable = setStatusIfApplicable;
 addCreateRoute.setOwnerIfApplicable = setOwnerIfApplicable;
 addCreateRoute.getFromReqObject = getFromReqObject;
+addCreateRoute.getData = getData;
 
 module.exports = addCreateRoute;
 

--- a/src/metadata/hydrate-schema.js
+++ b/src/metadata/hydrate-schema.js
@@ -45,9 +45,9 @@ function addStatusInfo(schema) {
             properties: {
                 status: schema.properties.status,
                 statusDate: schema.properties.statusDate,
-                data: schema.updateStatusSchema
+                data: schema.updateStatusSchema //todo anyof?
             },
-            required: ['status', 'statusDate', 'data'],
+            required: ['status', 'statusDate', 'data'], //todo - data check schema anyof?
             additionalProperties: false
         },
         additionalItems: false
@@ -84,7 +84,7 @@ function addOwnerInfo(schema) {
                     type: ['object', 'string'] //todo?
                 }
             },
-            required: ['owner', 'ownerDate', 'data'],
+            required: ['owner', 'ownerDate', 'data'], //todo - data check schema anyof?
             additionalProperties: false
         },
         additionalItems: false

--- a/src/routes/users/user.json
+++ b/src/routes/users/user.json
@@ -7,7 +7,12 @@
     "statuses": [
         {
             "name": "active",
-            "description": "Default status, shows that the user is active and can login"
+            "description": "Default status, shows that the user is active and can login",
+            "initialData":{
+                "static":{
+                    "reason":"testing"
+                }
+            }
         },
         {
             "name": "inactive",

--- a/test/@util/request-mocking.js
+++ b/test/@util/request-mocking.js
@@ -1,0 +1,56 @@
+'use strict';
+const httpMocks = require('node-mocks-http');
+const events = require('events');
+
+module.exports = {
+    mockRequest,
+    shouldNotCallNext,
+    shouldCallNext,
+    shouldNotReturnResponse
+};
+
+function mockRequest(middlewareOrRouter, reqOptions, responseCallback, nextCallback) {
+    const req = httpMocks.createRequest(reqOptions);
+    const res = httpMocks.createResponse({
+        eventEmitter: events.EventEmitter
+    });
+    res.on('end', function() {
+        let resToReturn;
+        try {
+            resToReturn = {
+                statusCode: res._getStatusCode(),
+                body: JSON.parse(res._getData()),
+                headers: res._getHeaders(),
+                raw: res
+            };
+        } catch (err) {
+            return responseCallback(err);
+        }
+        responseCallback(null, resToReturn);
+    });
+    middlewareOrRouter(req, res, nextCallback);
+}
+
+function shouldNotCallNext(done) {
+    return function next(err) {
+        if (err) {
+            return done(err);
+        }
+        return done(new Error('Next should not have been called'));
+    };
+}
+
+function shouldCallNext(done) {
+    return function next(err) {
+        if (err) {
+            return done(err);
+        }
+        return done();
+    };
+}
+
+function shouldNotReturnResponse(done) {
+    return function resComplete() {
+        done(new Error('res.end should not have been called'));
+    };
+}

--- a/test/crud/create.unit.js
+++ b/test/crud/create.unit.js
@@ -245,3 +245,27 @@ function mockRequest(middlewareOrRouter, reqOptions, responseCallback, nextCallb
     });
     middlewareOrRouter(req, res, nextCallback);
 }
+
+function shouldNotCallNext(done) {
+    return function next(err) {
+        if (err) {
+            return done(err);
+        }
+        return done(new Error('Next should not have been called'));
+    };
+}
+
+function shouldCallNext(done) {
+    return function next(err) {
+        if (err) {
+            return done(err);
+        }
+        return done();
+    };
+}
+
+function shouldNotReturnResponse(done) {
+    return function resComplete() {
+        done(new Error('res.end should not have been called'));
+    };
+}

--- a/test/crud/create.unit.js
+++ b/test/crud/create.unit.js
@@ -412,7 +412,6 @@ describe('Crud - create', function() {
             }).to.throw(notAString);
         });
 
-        //TODO what if value isn't found? should we use "asdasd: ['a','defaultValue']" to denote using defaults? or do we throw an error?
         it('Should use the default value if one was supplied', function() {
             const req = httpMocks.createRequest({
                 a: 'b'
@@ -422,6 +421,29 @@ describe('Crud - create', function() {
             };
             const result = addCreateRoute.getFromReqObject(map, req);
             expect(result.answer).to.equal('d');
+        });
+
+        it('Should use the first value in the array for the map if only that is specified', function() {
+            const req = httpMocks.createRequest({
+                a: 'b'
+            });
+            const map = {
+                answer: ['a']
+            };
+            const result = addCreateRoute.getFromReqObject(map, req);
+            expect(result.answer).to.equal('b');
+        });
+
+        it('Should throw an error if the first value in the array was not a string', function() {
+            const req = httpMocks.createRequest({
+                a: 'b'
+            });
+            const map = {
+                answer: [1]
+            };
+            expect(function() {
+                addCreateRoute.getFromReqObject(map, req);
+            }).to.throw(notAString);
         });
     });
 });

--- a/test/crud/create.unit.js
+++ b/test/crud/create.unit.js
@@ -217,11 +217,13 @@ describe('Crud - create', function() {
             const data = addCreateRoute.getData(null, {});
             expect(data).to.not.be.ok();
         });
+
         it('Should be an empty object if rules was an empty object', function() {
             const data = addCreateRoute.getData({}, {});
             expect(data).to.be.ok();
             expect(Object.keys(data)).to.have.lengthOf(0);
         });
+
         it('Should return an object that deep equals rules.static if only initialData.static was set', function() {
             const req = {};
             const rules = {
@@ -236,6 +238,7 @@ describe('Crud - create', function() {
             const data = addCreateRoute.getData(rules, req);
             expect(data).to.deep.equal(rules.static);
         });
+
         it('Should merge the result from getFromReqObject if rules.fromReq existed', function() {
             const req = {};
             const rules = {
@@ -249,6 +252,34 @@ describe('Crud - create', function() {
             const data = addCreateRoute.getData(rules, req);
             stub.restore();
             expect(data.bob).to.equal(true);
+        });
+        it('Should merge the result from getFromReqObject and static if both were set', function() {
+            const req = {};
+            const rules = {
+                fromReq: {},
+                static: {
+                    number: 1,
+                    string: 'test',
+                    bool: true,
+                    array: [2, 'test', true, null, {}, []],
+                    object: {
+                        subObject: {}
+                    }
+                }
+            };
+            const stubbedData = {
+                bob: true
+            };
+            const stub = sinon.stub(addCreateRoute, 'getFromReqObject');
+            stub.returns(stubbedData);
+            const data = addCreateRoute.getData(rules, req);
+            stub.restore();
+            expect(data.bob).to.equal(true);
+            expect(data.number).to.equal(rules.static.number);
+            expect(data.string).to.equal(rules.static.string);
+            expect(data.bool).to.equal(rules.static.bool);
+            expect(data.array).to.deep.equal(rules.static.array);
+            expect(data.object).to.deep.equal(rules.static.object);
         });
     });
 

--- a/test/crud/create.unit.js
+++ b/test/crud/create.unit.js
@@ -1,0 +1,72 @@
+'use strict';
+require('../@util/init.js');
+const addCreateRoute = require('../../src/crud/create');
+const httpMocks = require('node-mocks-http');
+const events = require('events');
+
+describe('Crud - create', function() {
+    describe('setStatusIfApplicable', function() {
+        it('Should not set req.body.status if the provided schema has no statuses', function(done) {
+            const metadata = buildMetadata();
+            const middleware = addCreateRoute.setStatusIfApplicable(metadata);
+            const reqOptions = {
+                body: {}
+            };
+            mockRequest(middleware, reqOptions, null, next);
+
+            function next(error) {
+                expect(error).to.not.be.ok();
+                expect(reqOptions.body.status).to.not.be.ok();
+                done();
+            }
+        });
+        it('Should set req.body.status to the first status in the schema', function(done) {
+            const metadata = buildMetadata([{ name: 'a' }, { name: 'b' }]);
+            const middleware = addCreateRoute.setStatusIfApplicable(metadata);
+            const reqOptions = {
+                body: {}
+            };
+            mockRequest(middleware, reqOptions, null, next);
+
+            function next(error) {
+                expect(error).to.not.be.ok();
+                expect(reqOptions.body.status).to.equal('a');
+                done();
+            }
+        });
+    });
+});
+
+function buildMetadata(statuses) {
+    const metadata = {
+        schemas: {
+            core: {}
+        }
+    };
+    if (statuses) {
+        metadata.schemas.core.statuses = statuses;
+    }
+    return metadata;
+}
+
+function mockRequest(middlewareOrRouter, reqOptions, responseCallback, nextCallback) {
+    const req = httpMocks.createRequest(reqOptions);
+    const res = httpMocks.createResponse({
+        eventEmitter: events.EventEmitter
+    });
+    res.on('end', function() {
+        let resToReturn;
+        try {
+            resToReturn = {
+                statusCode: res._getStatusCode(),
+                body: JSON.parse(res._getData()),
+                headers: res._getHeaders(),
+                raw: res
+            };
+        } catch (err) {
+            return responseCallback(err);
+        }
+        responseCallback(null, resToReturn);
+    });
+    middlewareOrRouter(req, res, nextCallback);
+}

--- a/test/crud/create.unit.js
+++ b/test/crud/create.unit.js
@@ -445,6 +445,30 @@ describe('Crud - create', function() {
                 addCreateRoute.getFromReqObject(map, req);
             }).to.throw(notAString);
         });
+
+        it('Should throw an error if the array is empty', function() {
+            const req = httpMocks.createRequest({
+                a: 'b'
+            });
+            const map = {
+                answer: []
+            };
+            expect(function() {
+                addCreateRoute.getFromReqObject(map, req);
+            }).to.throw(notAString);
+        });
+
+        it('Should throw an error if the array has more than 2 entries', function() {
+            const req = httpMocks.createRequest({
+                a: 'b'
+            });
+            const map = {
+                answer: ['a', 'a', 'a']
+            };
+            expect(function() {
+                addCreateRoute.getFromReqObject(map, req);
+            }).to.throw(/too many items in array/i);
+        });
     });
 });
 

--- a/test/crud/create.unit.js
+++ b/test/crud/create.unit.js
@@ -282,8 +282,6 @@ describe('Crud - create', function() {
     });
 
     describe('getFromReqObject', function() {
-        //TODO security around retrieving things from request? Maybe only from certain parts of req? req.params? req.query? req.body? req.process?
-
         it('Should map shallow properties from the req using the map', function() {
             const req = httpMocks.createRequest({
                 a: 'b'
@@ -468,6 +466,37 @@ describe('Crud - create', function() {
             expect(function() {
                 addCreateRoute.getFromReqObject(map, req);
             }).to.throw(/too many items in array/i);
+        });
+
+        //TODO security around retrieving things from request? Maybe only from certain parts of req? req.params? req.query? req.body? req.process?
+        //todo const allowedPrefixList = ['user', 'process', 'body', 'params', 'query'];
+        it('Should not allow map values that end with something on the exception list', function() {
+            const req = httpMocks.createRequest({
+                a: {
+                    b: 'c'
+                }
+            });
+            const map = {
+                answer: 'a.b'
+            };
+            const disallowedSuffixList = ['.b'];
+            expect(function() {
+                addCreateRoute.getFromReqObject(map, req, 0, disallowedSuffixList);
+            }).to.throw(/Map is not allowed to end with/i);
+        });
+
+        it('Should not allow map values that end with something on the default exception list', function() {
+            const req = httpMocks.createRequest({
+                a: {
+                    b: 'c'
+                }
+            });
+            const map = {
+                answer: 'a.password'
+            };
+            expect(function() {
+                addCreateRoute.getFromReqObject(map, req);
+            }).to.throw(/Map is not allowed to end with/i);
         });
     });
 });

--- a/test/crud/create.unit.js
+++ b/test/crud/create.unit.js
@@ -70,7 +70,9 @@ describe('Crud - create', function() {
             }
         });
 
-        it('Should create a status log entry with the status set to the first one in the schema', function(done) {
+        it('Should create a status log entry with the status set to the first one in the schema', function(
+            done
+        ) {
             const metadata = buildMetadata([{ name: 'a' }]);
             const middleware = addCreateRoute.setStatusIfApplicable(metadata);
             const reqOptions = {
@@ -95,7 +97,9 @@ describe('Crud - create', function() {
 
             function next(error) {
                 expect(error).to.not.be.ok();
-                expect(moment(reqOptions.body.statusLog[0].statusDate).diff(new Date())).to.be.lessThan(1);
+                expect(
+                    moment(reqOptions.body.statusLog[0].statusDate).diff(new Date())
+                ).to.be.lessThan(1);
                 done();
             }
         });

--- a/test/crud/create.unit.js
+++ b/test/crud/create.unit.js
@@ -140,72 +140,32 @@ describe('Crud - create', function() {
                 }
             });
 
-            it('Should be an object that deep equals initialData.static if only initialData.static was set', function(
-                done
-            ) {
+            it('Should be merge the result from getData', function(done) {
                 const statusToSet = {
                     name: 'a',
-                    initialData: {
-                        static: {
-                            number: 1,
-                            string: 'test',
-                            bool: true,
-                            array: [2, 'test', true, null, {}, []],
-                            object: {}
-                        }
-                    }
+                    initialData: {}
                 };
                 const metadata = buildMetadata([statusToSet]);
                 const middleware = addCreateRoute.setStatusIfApplicable(metadata);
                 const reqOptions = {
                     body: {}
                 };
+                const stubbedData = {
+                    bob: true,
+                    asd: {
+                        value: 1,
+                        name: 'bob'
+                    }
+                };
+                const stub = sinon.stub(addCreateRoute, 'getData');
+                stub.returns(stubbedData);
                 mockRequest(middleware, reqOptions, null, next);
 
                 function next(error) {
+                    stub.restore();
                     expect(error).to.not.be.ok();
                     const data = reqOptions.body.statusLog[0].data;
-                    expect(data).to.deep.equal(statusToSet.initialData.static);
-                    done();
-                }
-            });
-            it('Should be an object with properties taken from the request object if only initialData.fromReq was set', function(
-                done
-            ) {
-                const reqOptions = {
-                    body: {},
-                    user: {
-                        username: 'Bob'
-                    }
-                };
-                const statusToSet = {
-                    name: 'a',
-                    initialData: {
-                        fromReq: {
-                            username: 'user.username',
-                            doesNotExist: 'a',
-                            nested: {
-                                initialUsername: 'user.username'
-                            }
-                            //TODO what if not a string or object value? i.e. [boolean, null, undefined, array, number]
-                            //TODO what if value isn't found? should we use "asdasd: ['a','defaultValue']" to denote using defaults? or do we throw an error?
-                            //TODO security around retrieving things from request? Maybe only from certain parts of req? req.params? req.query? req.body? req.process?
-                            //TODO if fromReq and static are both set, it will merge in an order, what about conflicts? Error?
-                            //TODO refactor this fromReq code with detailed logic into it's own describe block for getFromReqObject
-                        }
-                    }
-                };
-                const metadata = buildMetadata([statusToSet]);
-                const middleware = addCreateRoute.setStatusIfApplicable(metadata);
-
-                mockRequest(middleware, reqOptions, null, next);
-
-                function next(error) {
-                    expect(error).to.not.be.ok();
-                    const data = reqOptions.body.statusLog[0].data;
-                    expect(data.username).to.equal('Bob');
-                    expect(data.doesNotExist).to.not.be.ok();
-                    expect(data.nested.initialUsername).to.equal('Bob');
+                    expect(data).to.deep.equal(stubbedData);
                     done();
                 }
             });
@@ -213,6 +173,8 @@ describe('Crud - create', function() {
     });
 
     describe('getData', function() {
+        //TODO if fromReq and static are both set, it will merge in an order, what about conflicts? Error?
+
         it('Should not exist if rules was falsy', function() {
             const data = addCreateRoute.getData(null, {});
             expect(data).to.not.be.ok();
@@ -253,6 +215,7 @@ describe('Crud - create', function() {
             stub.restore();
             expect(data.bob).to.equal(true);
         });
+
         it('Should merge the result from getFromReqObject and static if both were set', function() {
             const req = {};
             const rules = {
@@ -284,6 +247,10 @@ describe('Crud - create', function() {
     });
 
     describe('getFromReqObject', function() {
+        //TODO what if not a string or object value? i.e. [boolean, null, undefined, array, number]
+        //TODO what if value isn't found? should we use "asdasd: ['a','defaultValue']" to denote using defaults? or do we throw an error?
+        //TODO security around retrieving things from request? Maybe only from certain parts of req? req.params? req.query? req.body? req.process?
+
         it('Should map shallow properties from the req using the map', function() {
             const req = httpMocks.createRequest({
                 a: 'b'
@@ -294,6 +261,7 @@ describe('Crud - create', function() {
             const data = addCreateRoute.getFromReqObject(map, req);
             expect(data.answer).to.equal('b');
         });
+
         it('Should map deep properties from the req using the map', function() {
             const req = httpMocks.createRequest({
                 a: {

--- a/test/crud/create.unit.js
+++ b/test/crud/create.unit.js
@@ -69,7 +69,9 @@ describe('Crud - create', function() {
             }
         });
 
-        it('Should create a status log entry with the status set to the first one in the schema', function(done) {
+        it('Should create a status log entry with the status set to the first one in the schema', function(
+            done
+        ) {
             const metadata = buildMetadata([{ name: 'a' }]);
             const middleware = addCreateRoute.setStatusIfApplicable(metadata);
             const reqOptions = {
@@ -94,7 +96,9 @@ describe('Crud - create', function() {
 
             function next(error) {
                 expect(error).to.not.be.ok();
-                expect(moment(reqOptions.body.statusLog[0].statusDate).diff(new Date())).to.be.lessThan(1);
+                expect(
+                    moment(reqOptions.body.statusLog[0].statusDate).diff(new Date())
+                ).to.be.lessThan(1);
                 done();
             }
         });
@@ -272,6 +276,20 @@ describe('Crud - create', function() {
             };
             const data = addCreateRoute.getFromReqObject(map, req);
             expect(data.nested.answer).to.equal('c');
+        });
+        it('Should throw an error for circular reference maps', function() {
+            const req = httpMocks.createRequest({
+                a: {
+                    b: 'c'
+                }
+            });
+            const map = {
+                nested: {}
+            };
+            map.nested.answer = map;
+            expect(function() {
+                addCreateRoute.getFromReqObject(map, req);
+            }).to.throw(/circular reference/i);
         });
     });
 });

--- a/test/crud/create.unit.js
+++ b/test/crud/create.unit.js
@@ -1,10 +1,10 @@
 'use strict';
 require('../@util/init.js');
 const addCreateRoute = require('../../src/crud/create');
-const httpMocks = require('node-mocks-http');
-const events = require('events');
+const mockRequest = require('../@util/request-mocking').mockRequest;
 const moment = require('moment');
 const sinon = require('sinon');
+const httpMocks = require('node-mocks-http');
 
 describe('Crud - create', function() {
     describe('setStatusIfApplicable', function() {
@@ -541,49 +541,3 @@ function buildMetadata(statuses) {
     }
     return metadata;
 }
-
-function mockRequest(middlewareOrRouter, reqOptions, responseCallback, nextCallback) {
-    const req = httpMocks.createRequest(reqOptions);
-    const res = httpMocks.createResponse({
-        eventEmitter: events.EventEmitter
-    });
-    res.on('end', function() {
-        let resToReturn;
-        try {
-            resToReturn = {
-                statusCode: res._getStatusCode(),
-                body: JSON.parse(res._getData()),
-                headers: res._getHeaders(),
-                raw: res
-            };
-        } catch (err) {
-            return responseCallback(err);
-        }
-        responseCallback(null, resToReturn);
-    });
-    middlewareOrRouter(req, res, nextCallback);
-}
-
-// function shouldNotCallNext(done) {
-//     return function next(err) {
-//         if (err) {
-//             return done(err);
-//         }
-//         return done(new Error('Next should not have been called'));
-//     };
-// }
-//
-// function shouldCallNext(done) {
-//     return function next(err) {
-//         if (err) {
-//             return done(err);
-//         }
-//         return done();
-//     };
-// }
-//
-// function shouldNotReturnResponse(done) {
-//     return function resComplete() {
-//         done(new Error('res.end should not have been called'));
-//     };
-// }

--- a/test/crud/create.unit.js
+++ b/test/crud/create.unit.js
@@ -173,8 +173,6 @@ describe('Crud - create', function() {
     });
 
     describe('getData', function() {
-        //TODO if fromReq and static are both set, it will merge in an order, what about conflicts? Error?
-
         it('Should not exist if rules was falsy', function() {
             const data = addCreateRoute.getData(null, {});
             expect(data).to.not.be.ok();
@@ -243,6 +241,43 @@ describe('Crud - create', function() {
             expect(data.bool).to.equal(rules.static.bool);
             expect(data.array).to.deep.equal(rules.static.array);
             expect(data.object).to.deep.equal(rules.static.object);
+        });
+
+        it('Should prioritise fields from getFromReqObject over static if both were set', function() {
+            const req = {};
+            const rules = {
+                fromReq: {},
+                static: {
+                    number: 1,
+                    string: 'test',
+                    bool: true,
+                    array: [2, 'test', true, null, {}, []],
+                    object: {
+                        subObject: {}
+                    }
+                }
+            };
+            const stubbedData = {
+                bob: true,
+                number: 2,
+                string: 'test2',
+                bool: false,
+                array: [],
+                object: {
+                    betterSubObject: {}
+                }
+            };
+            const stub = sinon.stub(addCreateRoute, 'getFromReqObject');
+            stub.returns(stubbedData);
+            const data = addCreateRoute.getData(rules, req);
+            stub.restore();
+            expect(data.bob).to.equal(true);
+            expect(data.number).to.equal(stubbedData.number);
+            expect(data.string).to.equal(stubbedData.string);
+            expect(data.bool).to.equal(stubbedData.bool);
+            expect(data.array).to.deep.equal(rules.static.array);
+            expect(data.object.subObject).to.be.ok;
+            expect(data.object.betterSubObject).to.be.ok;
         });
     });
 

--- a/test/crud/create.unit.js
+++ b/test/crud/create.unit.js
@@ -352,6 +352,81 @@ describe('Crud - create', function() {
                 addCreateRoute.getFromReqObject(map, req);
             }).to.throw(/circular reference/i);
         });
+
+        const notAString = /must be a string/i;
+
+        it('Should throw an error if the map was a number', function() {
+            const req = httpMocks.createRequest({
+                a: 'b'
+            });
+            const map = {
+                answer: 1
+            };
+            expect(function() {
+                addCreateRoute.getFromReqObject(map, req);
+            }).to.throw(notAString);
+        });
+
+        it('Should throw an error if the map was a boolean', function() {
+            const req = httpMocks.createRequest({
+                a: 'b'
+            });
+            const map = {
+                answer: true
+            };
+            expect(function() {
+                addCreateRoute.getFromReqObject(map, req);
+            }).to.throw(notAString);
+        });
+
+        it('Should not throw an error if the map was an empty object', function() {
+            const req = httpMocks.createRequest({
+                a: 'b'
+            });
+            const map = {
+                answer: {}
+            };
+            const data = addCreateRoute.getFromReqObject(map, req);
+            expect(data.answer).to.deep.equal({});
+        });
+
+        it('Should throw an error if the map was null', function() {
+            const req = httpMocks.createRequest({
+                a: 'b'
+            });
+            const map = {
+                answer: null
+            };
+            expect(function() {
+                addCreateRoute.getFromReqObject(map, req);
+            }).to.throw(notAString);
+        });
+
+        it('Should throw an error if the map was undefined', function() {
+            const req = httpMocks.createRequest({
+                a: 'b'
+            });
+            const map = {
+                answer: undefined
+            };
+            expect(function() {
+                addCreateRoute.getFromReqObject(map, req);
+            }).to.throw(notAString);
+        });
+
+        it('Should <doSomething> if the map was a array', function() {
+            const req = httpMocks.createRequest({
+                a: 'b'
+            });
+            const map = {
+                option1: ['asdasd', 12], //defaultValue?
+                option2: [], //throw error?
+                option3: ['a.doesNotExist', 'a.b'] // try get first one, if fails go onto next?
+            };
+            expect(function() {
+                addCreateRoute.getFromReqObject(map, req);
+            }).to.throw(notAString);
+        });
     });
 });
 

--- a/test/crud/create.unit.js
+++ b/test/crud/create.unit.js
@@ -3,6 +3,7 @@ require('../@util/init.js');
 const addCreateRoute = require('../../src/crud/create');
 const httpMocks = require('node-mocks-http');
 const events = require('events');
+const moment = require('moment');
 
 describe('Crud - create', function() {
     describe('setStatusIfApplicable', function() {
@@ -17,9 +18,12 @@ describe('Crud - create', function() {
             function next(error) {
                 expect(error).to.not.be.ok();
                 expect(reqOptions.body.status).to.not.be.ok();
+                expect(reqOptions.body.statusDate).to.not.be.ok();
+                expect(reqOptions.body.statusLog).to.not.be.ok();
                 done();
             }
         });
+
         it('Should set req.body.status to the first status in the schema', function(done) {
             const metadata = buildMetadata([{ name: 'a' }, { name: 'b' }]);
             const middleware = addCreateRoute.setStatusIfApplicable(metadata);
@@ -31,6 +35,35 @@ describe('Crud - create', function() {
             function next(error) {
                 expect(error).to.not.be.ok();
                 expect(reqOptions.body.status).to.equal('a');
+                done();
+            }
+        });
+
+        it('Should set req.body.statusDate to now', function(done) {
+            const metadata = buildMetadata([{ name: 'a' }]);
+            const middleware = addCreateRoute.setStatusIfApplicable(metadata);
+            const reqOptions = {
+                body: {}
+            };
+            mockRequest(middleware, reqOptions, null, next);
+
+            function next(error) {
+                expect(error).to.not.be.ok();
+                expect(moment(reqOptions.body.statusDate).diff(new Date())).to.be.lessThan(1);
+                done();
+            }
+        });
+        it('Should create a status log with one entry', function(done) {
+            const metadata = buildMetadata([{ name: 'a' }]);
+            const middleware = addCreateRoute.setStatusIfApplicable(metadata);
+            const reqOptions = {
+                body: {}
+            };
+            mockRequest(middleware, reqOptions, null, next);
+
+            function next(error) {
+                expect(error).to.not.be.ok();
+                expect(reqOptions.body.statusLog).to.be.an('array').that.has.length(1);
                 done();
             }
         });

--- a/test/crud/create.unit.js
+++ b/test/crud/create.unit.js
@@ -210,8 +210,69 @@ describe('Crud - create', function() {
             });
         });
     });
-    describe('getFromReqObject', function() {
 
+    describe('getData', function() {
+        it('Should not exist if rules was falsy', function() {
+            const data = addCreateRoute.getData(null, {});
+            expect(data).to.not.be.ok();
+        });
+        it('Should be an empty object if rules was an empty object', function() {
+            const data = addCreateRoute.getData({}, {});
+            expect(data).to.be.ok();
+            expect(Object.keys(data)).to.have.lengthOf(0);
+        });
+    });
+
+    describe('getFromReqObject', function() {
+        it('Should map shallow properties from the req using the map', function() {
+            const req = httpMocks.createRequest({
+                a: 'b'
+            });
+            const map = {
+                answer: 'a'
+            };
+            const data = addCreateRoute.getFromReqObject(map, req);
+            expect(data.answer).to.equal('b');
+        });
+        it('Should map deep properties from the req using the map', function() {
+            const req = httpMocks.createRequest({
+                a: {
+                    b: 'c'
+                }
+            });
+            const map = {
+                answer: 'a.b'
+            };
+            const data = addCreateRoute.getFromReqObject(map, req);
+            expect(data.answer).to.equal('c');
+        });
+
+        it('Should support a nested map structure', function() {
+            const req = httpMocks.createRequest({
+                a: 'b'
+            });
+            const map = {
+                nested: {
+                    answer: 'a'
+                }
+            };
+            const data = addCreateRoute.getFromReqObject(map, req);
+            expect(data.nested.answer).to.equal('b');
+        });
+        it('Should support a nested map structure with a nested request object', function() {
+            const req = httpMocks.createRequest({
+                a: {
+                    b: 'c'
+                }
+            });
+            const map = {
+                nested: {
+                    answer: 'a.b'
+                }
+            };
+            const data = addCreateRoute.getFromReqObject(map, req);
+            expect(data.nested.answer).to.equal('c');
+        });
     });
 });
 

--- a/test/crud/create.unit.js
+++ b/test/crud/create.unit.js
@@ -53,6 +53,7 @@ describe('Crud - create', function() {
                 done();
             }
         });
+
         it('Should create a status log with one entry', function(done) {
             const metadata = buildMetadata([{ name: 'a' }]);
             const middleware = addCreateRoute.setStatusIfApplicable(metadata);
@@ -64,6 +65,36 @@ describe('Crud - create', function() {
             function next(error) {
                 expect(error).to.not.be.ok();
                 expect(reqOptions.body.statusLog).to.be.an('array').that.has.length(1);
+                done();
+            }
+        });
+
+        it('Should create a status log entry with the status set to the first one in the schema', function(done) {
+            const metadata = buildMetadata([{ name: 'a' }]);
+            const middleware = addCreateRoute.setStatusIfApplicable(metadata);
+            const reqOptions = {
+                body: {}
+            };
+            mockRequest(middleware, reqOptions, null, next);
+
+            function next(error) {
+                expect(error).to.not.be.ok();
+                expect(reqOptions.body.statusLog[0].status).to.equal('a');
+                done();
+            }
+        });
+
+        it('Should create a status log entry with the statusDate set to now', function(done) {
+            const metadata = buildMetadata([{ name: 'a' }]);
+            const middleware = addCreateRoute.setStatusIfApplicable(metadata);
+            const reqOptions = {
+                body: {}
+            };
+            mockRequest(middleware, reqOptions, null, next);
+
+            function next(error) {
+                expect(error).to.not.be.ok();
+                expect(moment(reqOptions.body.statusLog[0].statusDate).diff(new Date())).to.be.lessThan(1);
                 done();
             }
         });

--- a/test/crud/create.unit.js
+++ b/test/crud/create.unit.js
@@ -289,7 +289,7 @@ describe('Crud - create', function() {
             const map = {
                 answer: 'a'
             };
-            const data = addCreateRoute.getFromReqObject(map, req);
+            const data = addCreateRoute.getFromReqObject(map, req, 0, undefined, ['a']);
             expect(data.answer).to.equal('b');
         });
 
@@ -302,7 +302,7 @@ describe('Crud - create', function() {
             const map = {
                 answer: 'a.b'
             };
-            const data = addCreateRoute.getFromReqObject(map, req);
+            const data = addCreateRoute.getFromReqObject(map, req, 0, undefined, ['a']);
             expect(data.answer).to.equal('c');
         });
 
@@ -315,7 +315,7 @@ describe('Crud - create', function() {
                     answer: 'a'
                 }
             };
-            const data = addCreateRoute.getFromReqObject(map, req);
+            const data = addCreateRoute.getFromReqObject(map, req, 0, undefined, ['a']);
             expect(data.nested.answer).to.equal('b');
         });
 
@@ -330,7 +330,7 @@ describe('Crud - create', function() {
                     answer: 'a.b'
                 }
             };
-            const data = addCreateRoute.getFromReqObject(map, req);
+            const data = addCreateRoute.getFromReqObject(map, req, 0, undefined, ['a']);
             expect(data.nested.answer).to.equal('c');
         });
 
@@ -417,7 +417,7 @@ describe('Crud - create', function() {
             const map = {
                 answer: ['c', 'd']
             };
-            const result = addCreateRoute.getFromReqObject(map, req);
+            const result = addCreateRoute.getFromReqObject(map, req, 0, undefined, ['c']);
             expect(result.answer).to.equal('d');
         });
 
@@ -428,7 +428,7 @@ describe('Crud - create', function() {
             const map = {
                 answer: ['a']
             };
-            const result = addCreateRoute.getFromReqObject(map, req);
+            const result = addCreateRoute.getFromReqObject(map, req, 0, undefined, ['a']);
             expect(result.answer).to.equal('b');
         });
 
@@ -468,8 +468,7 @@ describe('Crud - create', function() {
             }).to.throw(/too many items in array/i);
         });
 
-        //TODO security around retrieving things from request? Maybe only from certain parts of req? req.params? req.query? req.body? req.process?
-        //todo const allowedPrefixList = ['user', 'process', 'body', 'params', 'query'];
+        const invalidSuffix = /Map is not allowed to end with/i;
         it('Should not allow map values that end with something on the exception list', function() {
             const req = httpMocks.createRequest({
                 a: {
@@ -482,7 +481,7 @@ describe('Crud - create', function() {
             const disallowedSuffixList = ['.b'];
             expect(function() {
                 addCreateRoute.getFromReqObject(map, req, 0, disallowedSuffixList);
-            }).to.throw(/Map is not allowed to end with/i);
+            }).to.throw(invalidSuffix);
         });
 
         it('Should not allow map values that end with something on the default exception list', function() {
@@ -496,7 +495,37 @@ describe('Crud - create', function() {
             };
             expect(function() {
                 addCreateRoute.getFromReqObject(map, req);
-            }).to.throw(/Map is not allowed to end with/i);
+            }).to.throw(invalidSuffix);
+        });
+
+        const invalidPrefix = /Map must start with one of /i;
+        it('Should not allow access to req properties are not on the exception list', function() {
+            const req = httpMocks.createRequest({
+                a: {
+                    b: 'c'
+                }
+            });
+            const map = {
+                answer: 'a.b'
+            };
+            const allowedPrefixList = [];
+            expect(function() {
+                addCreateRoute.getFromReqObject(map, req, 0, undefined, allowedPrefixList);
+            }).to.throw(invalidPrefix);
+        });
+
+        it('Should not allow map values that end with something on the default exception list', function() {
+            const req = httpMocks.createRequest({
+                body: {
+                    b: 'c'
+                }
+            });
+            const map = {
+                answer: 'body.password'
+            };
+            expect(function() {
+                addCreateRoute.getFromReqObject(map, req);
+            }).to.throw(invalidSuffix);
         });
     });
 });

--- a/test/crud/create.unit.js
+++ b/test/crud/create.unit.js
@@ -210,6 +210,9 @@ describe('Crud - create', function() {
             });
         });
     });
+    describe('getFromReqObject', function() {
+
+    });
 });
 
 function buildMetadata(statuses) {
@@ -246,26 +249,26 @@ function mockRequest(middlewareOrRouter, reqOptions, responseCallback, nextCallb
     middlewareOrRouter(req, res, nextCallback);
 }
 
-function shouldNotCallNext(done) {
-    return function next(err) {
-        if (err) {
-            return done(err);
-        }
-        return done(new Error('Next should not have been called'));
-    };
-}
-
-function shouldCallNext(done) {
-    return function next(err) {
-        if (err) {
-            return done(err);
-        }
-        return done();
-    };
-}
-
-function shouldNotReturnResponse(done) {
-    return function resComplete() {
-        done(new Error('res.end should not have been called'));
-    };
-}
+// function shouldNotCallNext(done) {
+//     return function next(err) {
+//         if (err) {
+//             return done(err);
+//         }
+//         return done(new Error('Next should not have been called'));
+//     };
+// }
+//
+// function shouldCallNext(done) {
+//     return function next(err) {
+//         if (err) {
+//             return done(err);
+//         }
+//         return done();
+//     };
+// }
+//
+// function shouldNotReturnResponse(done) {
+//     return function resComplete() {
+//         done(new Error('res.end should not have been called'));
+//     };
+// }

--- a/test/crud/create.unit.js
+++ b/test/crud/create.unit.js
@@ -282,8 +282,6 @@ describe('Crud - create', function() {
     });
 
     describe('getFromReqObject', function() {
-        //TODO what if not a string or object value? i.e. [boolean, null, undefined, array, number]
-        //TODO what if value isn't found? should we use "asdasd: ['a','defaultValue']" to denote using defaults? or do we throw an error?
         //TODO security around retrieving things from request? Maybe only from certain parts of req? req.params? req.query? req.body? req.process?
 
         it('Should map shallow properties from the req using the map', function() {
@@ -414,18 +412,16 @@ describe('Crud - create', function() {
             }).to.throw(notAString);
         });
 
-        it('Should <doSomething> if the map was a array', function() {
+        //TODO what if value isn't found? should we use "asdasd: ['a','defaultValue']" to denote using defaults? or do we throw an error?
+        it('Should use the default value if one was supplied', function() {
             const req = httpMocks.createRequest({
                 a: 'b'
             });
             const map = {
-                option1: ['asdasd', 12], //defaultValue?
-                option2: [], //throw error?
-                option3: ['a.doesNotExist', 'a.b'] // try get first one, if fails go onto next?
+                answer: ['c', 'd']
             };
-            expect(function() {
-                addCreateRoute.getFromReqObject(map, req);
-            }).to.throw(notAString);
+            const result = addCreateRoute.getFromReqObject(map, req);
+            expect(result.answer).to.equal('d');
         });
     });
 });


### PR DESCRIPTION
Updating the code so that on creation of objects that use statuses you can either set some static data in the                 status log or get some data from the `req` object