### PR TITLE
Export crud functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Node Api Seed Change Log
 
 ## [Unreleased](https://github.com/eXigentCoder/node-api-seed/compare/v1.1.1...HEAD)
+* Refactoring generic CRUD functions to export all their functions as properties on an object rather than tacked on to the primary function. This will allow for easier unit testing
 
 Check here for upcoming changes
 

--- a/src/crud/create.js
+++ b/src/crud/create.js
@@ -94,7 +94,9 @@ function description(metadata) {
         responses: {
             '201': {
                 description:
-                    'Informs the caller that the ' + metadata.title.toLowerCase() + ' was successfully created.',
+                    'Informs the caller that the ' +
+                        metadata.title.toLowerCase() +
+                        ' was successfully created.',
                 commonHeaders: [correlationIdOptions.resHeader],
                 model: metadata.schemas.output.name
             }
@@ -160,13 +162,21 @@ function getFromReqObject(
         if (_.isArray(value)) {
             ensureMapIsString(value[0]);
             if (value.length > 2) {
-                throw new Error(util.format('Too many items in array, should be at most 2. %j', value));
+                throw new Error(
+                    util.format('Too many items in array, should be at most 2. %j', value)
+                );
             }
             data[key] = getValue(req, value[0], value[1], disallowedSuffixList, allowedPrefixList);
             return;
         }
         if (_.isObject(value)) {
-            data[key] = getFromReqObject(value, req, depth + 1, disallowedSuffixList, allowedPrefixList);
+            data[key] = getFromReqObject(
+                value,
+                req,
+                depth + 1,
+                disallowedSuffixList,
+                allowedPrefixList
+            );
             return;
         }
         ensureMapIsString(value);
@@ -203,7 +213,12 @@ function setOwnerIfApplicable(metadata) {
             req.body.owner = _.get(req, ownership.setOwnerExpression);
             if (!req.body.owner) {
                 return next(
-                    boom.badRequest(util.format('Owner from expression "%s" was blank', ownership.setOwnerExpression))
+                    boom.badRequest(
+                        util.format(
+                            'Owner from expression "%s" was blank',
+                            ownership.setOwnerExpression
+                        )
+                    )
                 );
             }
         } else {

--- a/src/crud/delete-by-id.js
+++ b/src/crud/delete-by-id.js
@@ -6,12 +6,18 @@ const addModel = require('../swagger/add-model');
 const config = require('nconf');
 const permissions = require('../permissions');
 
-module.exports = function addDeleteByIdRoute(router, crudMiddleware, maps) {
+module.exports = {
+    addDeleteByIdRoute,
+    getSteps,
+    description
+};
+
+function addDeleteByIdRoute(router, crudMiddleware, maps) {
     router
         .delete('/:' + router.metadata.identifierName, getSteps(router, crudMiddleware, maps))
         .describe(router.metadata.getByIdDescription || description(router.metadata));
     return router;
-};
+}
 
 function getSteps(router, crudMiddleware, maps) {
     const steps = {
@@ -30,19 +36,12 @@ function description(metadata) {
     return {
         security: true,
         summary:
-            'Removes ' +
-                metadata.aOrAn +
-                ' ' +
-                metadata.title +
-                ' By ' +
-                _.startCase(metadata.identifierName) +
-                '.',
+            'Removes ' + metadata.aOrAn + ' ' + metadata.title + ' By ' + _.startCase(metadata.identifierName) + '.',
         tags: [metadata.tag.name],
         parameters: [
             {
                 name: metadata.identifierName,
-                description:
-                    'The field to uniquely identify this ' + metadata.title.toLowerCase() + '.',
+                description: 'The field to uniquely identify this ' + metadata.title.toLowerCase() + '.',
                 required: true,
                 in: 'path',
                 type: 'string'

--- a/src/crud/delete-by-id.js
+++ b/src/crud/delete-by-id.js
@@ -36,12 +36,19 @@ function description(metadata) {
     return {
         security: true,
         summary:
-            'Removes ' + metadata.aOrAn + ' ' + metadata.title + ' By ' + _.startCase(metadata.identifierName) + '.',
+            'Removes ' +
+                metadata.aOrAn +
+                ' ' +
+                metadata.title +
+                ' By ' +
+                _.startCase(metadata.identifierName) +
+                '.',
         tags: [metadata.tag.name],
         parameters: [
             {
                 name: metadata.identifierName,
-                description: 'The field to uniquely identify this ' + metadata.title.toLowerCase() + '.',
+                description:
+                    'The field to uniquely identify this ' + metadata.title.toLowerCase() + '.',
                 required: true,
                 in: 'path',
                 type: 'string'

--- a/src/crud/get-by-id-and-use.js
+++ b/src/crud/get-by-id-and-use.js
@@ -5,13 +5,12 @@ const util = require('util');
 const _ = require('lodash');
 const permissions = require('../permissions');
 
-module.exports = function addGetByIdAndUseRoute(
-    router,
-    path,
-    routerOrMiddleware,
-    crudMiddleware,
-    maps
-) {
+module.exports = {
+    addGetByIdAndUseRoute,
+    getByIdAndUseSteps
+};
+
+function addGetByIdAndUseRoute(router, path, routerOrMiddleware, crudMiddleware, maps) {
     if (_.isObject(path)) {
         //path omitted, move all args up by one.
         maps = crudMiddleware;
@@ -40,7 +39,7 @@ module.exports = function addGetByIdAndUseRoute(
     const steps = getByIdAndUseSteps(router, routerOrMiddleware, crudMiddleware, maps);
     router.use('/:' + router.metadata.identifierName + path, steps);
     return router;
-};
+}
 
 function getByIdAndUseSteps(router, routerOrMiddleware, crudMiddleware, maps) {
     const steps = {

--- a/src/crud/get-by-id.js
+++ b/src/crud/get-by-id.js
@@ -45,7 +45,8 @@ function description(metadata) {
         parameters: [
             {
                 name: metadata.identifierName,
-                description: 'The field to uniquely identify this ' + metadata.title.toLowerCase() + '.',
+                description:
+                    'The field to uniquely identify this ' + metadata.title.toLowerCase() + '.',
                 required: true,
                 in: 'path',
                 type: 'string'
@@ -59,7 +60,8 @@ function description(metadata) {
         },
         responses: {
             '200': {
-                description: 'Returns the single ' + metadata.title + ' matching the provided parameters.',
+                description:
+                    'Returns the single ' + metadata.title + ' matching the provided parameters.',
                 model: metadata.schemas.output.name,
                 commonHeaders: [correlationIdOptions.resHeader]
             }

--- a/src/crud/get-by-id.js
+++ b/src/crud/get-by-id.js
@@ -6,12 +6,18 @@ const addModel = require('../swagger/add-model');
 const config = require('nconf');
 const permissions = require('../permissions');
 
-module.exports = function addGetByIdRoute(router, crudMiddleware, maps) {
+module.exports = {
+    addGetByIdRoute,
+    getSteps,
+    description
+};
+
+function addGetByIdRoute(router, crudMiddleware, maps) {
     router
         .get('/:' + router.metadata.identifierName, getSteps(router, crudMiddleware, maps))
         .describe(router.metadata.getByIdDescription || description(router.metadata));
     return router;
-};
+}
 
 function getSteps(router, crudMiddleware, maps) {
     const steps = {
@@ -39,8 +45,7 @@ function description(metadata) {
         parameters: [
             {
                 name: metadata.identifierName,
-                description:
-                    'The field to uniquely identify this ' + metadata.title.toLowerCase() + '.',
+                description: 'The field to uniquely identify this ' + metadata.title.toLowerCase() + '.',
                 required: true,
                 in: 'path',
                 type: 'string'
@@ -54,8 +59,7 @@ function description(metadata) {
         },
         responses: {
             '200': {
-                description:
-                    'Returns the single ' + metadata.title + ' matching the provided parameters.',
+                description: 'Returns the single ' + metadata.title + ' matching the provided parameters.',
                 model: metadata.schemas.output.name,
                 commonHeaders: [correlationIdOptions.resHeader]
             }

--- a/src/crud/query.js
+++ b/src/crud/query.js
@@ -5,12 +5,18 @@ const addModel = require('../swagger/add-model');
 const config = require('nconf');
 const permissions = require('../permissions');
 
-module.exports = function addQueryRoute(router, crudMiddleware, maps) {
+module.exports = {
+    addQueryRoute,
+    getSteps,
+    description
+};
+
+function addQueryRoute(router, crudMiddleware, maps) {
     router
         .get('/', getSteps(router, crudMiddleware, maps))
         .describe(router.metadata.queryDescription || description(router.metadata));
     return router;
-};
+}
 
 function getSteps(router, crudMiddleware, maps) {
     const steps = {
@@ -44,10 +50,7 @@ function description(metadata) {
         },
         responses: {
             200: {
-                description:
-                    'Returns the list of ' +
-                        metadata.titlePlural +
-                        ' matching the supplied parameters.',
+                description: 'Returns the list of ' + metadata.titlePlural + ' matching the supplied parameters.',
                 arrayOfModel: metadata.schemas.output.name,
                 commonHeaders: [correlationIdOptions.resHeader]
             }

--- a/src/crud/query.js
+++ b/src/crud/query.js
@@ -50,7 +50,10 @@ function description(metadata) {
         },
         responses: {
             200: {
-                description: 'Returns the list of ' + metadata.titlePlural + ' matching the supplied parameters.',
+                description:
+                    'Returns the list of ' +
+                        metadata.titlePlural +
+                        ' matching the supplied parameters.',
                 arrayOfModel: metadata.schemas.output.name,
                 commonHeaders: [correlationIdOptions.resHeader]
             }

--- a/src/crud/router/add-standard-routes.js
+++ b/src/crud/router/add-standard-routes.js
@@ -39,10 +39,10 @@ module.exports = function addStandardRoutes(router) {
     router.update = function(crudMiddleware, maps) {
         if (router.crudMiddleware) {
             if (_.isNil(maps)) {
-                return update(router, router.crudMiddleware, crudMiddleware);
+                return update.addUpdateRoute(router, router.crudMiddleware, crudMiddleware);
             }
         }
-        return update(router, crudMiddleware, maps);
+        return update.addUpdateRoute(router, crudMiddleware, maps);
     };
     router.updateStatus = function(crudMiddleware, maps) {
         if (router.crudMiddleware) {

--- a/src/crud/router/add-standard-routes.js
+++ b/src/crud/router/add-standard-routes.js
@@ -47,7 +47,11 @@ module.exports = function addStandardRoutes(router) {
     router.updateStatus = function(crudMiddleware, maps) {
         if (router.crudMiddleware) {
             if (_.isNil(maps)) {
-                return updateStatus.addUpdateStatusRoute(router, router.crudMiddleware, crudMiddleware);
+                return updateStatus.addUpdateStatusRoute(
+                    router,
+                    router.crudMiddleware,
+                    crudMiddleware
+                );
             }
         }
         return updateStatus.addUpdateStatusRoute(router, crudMiddleware, maps);
@@ -72,6 +76,12 @@ module.exports = function addStandardRoutes(router) {
                 );
             }
         }
-        return getByIdAndUse.addGetByIdAndUseRoute(router, path, routerOrMiddleware, crudMiddleware, maps);
+        return getByIdAndUse.addGetByIdAndUseRoute(
+            router,
+            path,
+            routerOrMiddleware,
+            crudMiddleware,
+            maps
+        );
     };
 };

--- a/src/crud/router/add-standard-routes.js
+++ b/src/crud/router/add-standard-routes.js
@@ -55,10 +55,10 @@ module.exports = function addStandardRoutes(router) {
     router.deleteById = function(crudMiddleware, maps) {
         if (router.crudMiddleware) {
             if (_.isNil(maps)) {
-                return deleteById(router, router.crudMiddleware, crudMiddleware);
+                return deleteById.addDeleteByIdRoute(router, router.crudMiddleware, crudMiddleware);
             }
         }
-        return deleteById(router, crudMiddleware, maps);
+        return deleteById.addDeleteByIdRoute(router, crudMiddleware, maps);
     };
     router.getByIdAndUse = function(path, routerOrMiddleware, crudMiddleware, maps) {
         if (router.crudMiddleware) {

--- a/src/crud/router/add-standard-routes.js
+++ b/src/crud/router/add-standard-routes.js
@@ -47,10 +47,10 @@ module.exports = function addStandardRoutes(router) {
     router.updateStatus = function(crudMiddleware, maps) {
         if (router.crudMiddleware) {
             if (_.isNil(maps)) {
-                return updateStatus(router, router.crudMiddleware, crudMiddleware);
+                return updateStatus.addUpdateStatusRoute(router, router.crudMiddleware, crudMiddleware);
             }
         }
-        return updateStatus(router, crudMiddleware, maps);
+        return updateStatus.addUpdateStatusRoute(router, crudMiddleware, maps);
     };
     router.deleteById = function(crudMiddleware, maps) {
         if (router.crudMiddleware) {

--- a/src/crud/router/add-standard-routes.js
+++ b/src/crud/router/add-standard-routes.js
@@ -23,10 +23,10 @@ module.exports = function addStandardRoutes(router) {
     router.getById = function(crudMiddleware, maps) {
         if (router.crudMiddleware) {
             if (_.isNil(maps)) {
-                return getById(router, router.crudMiddleware, crudMiddleware);
+                return getById.addGetByIdRoute(router, router.crudMiddleware, crudMiddleware);
             }
         }
-        return getById(router, crudMiddleware, maps);
+        return getById.addGetByIdRoute(router, crudMiddleware, maps);
     };
     router.create = function(crudMiddleware, maps) {
         if (router.crudMiddleware) {

--- a/src/crud/router/add-standard-routes.js
+++ b/src/crud/router/add-standard-routes.js
@@ -63,7 +63,7 @@ module.exports = function addStandardRoutes(router) {
     router.getByIdAndUse = function(path, routerOrMiddleware, crudMiddleware, maps) {
         if (router.crudMiddleware) {
             if (_.isNil(maps)) {
-                return getByIdAndUse(
+                return getByIdAndUse.addGetByIdAndUseRoute(
                     router,
                     path,
                     routerOrMiddleware,
@@ -72,6 +72,6 @@ module.exports = function addStandardRoutes(router) {
                 );
             }
         }
-        return getByIdAndUse(router, path, routerOrMiddleware, crudMiddleware, maps);
+        return getByIdAndUse.addGetByIdAndUseRoute(router, path, routerOrMiddleware, crudMiddleware, maps);
     };
 };

--- a/src/crud/router/add-standard-routes.js
+++ b/src/crud/router/add-standard-routes.js
@@ -31,10 +31,10 @@ module.exports = function addStandardRoutes(router) {
     router.create = function(crudMiddleware, maps) {
         if (router.crudMiddleware) {
             if (_.isNil(maps)) {
-                return create(router, router.crudMiddleware, crudMiddleware);
+                return create.addCreateRoute(router, router.crudMiddleware, crudMiddleware);
             }
         }
-        return create(router, crudMiddleware, maps);
+        return create.addCreateRoute(router, crudMiddleware, maps);
     };
     router.update = function(crudMiddleware, maps) {
         if (router.crudMiddleware) {

--- a/src/crud/router/add-standard-routes.js
+++ b/src/crud/router/add-standard-routes.js
@@ -15,10 +15,10 @@ module.exports = function addStandardRoutes(router) {
     router.query = function(crudMiddleware, maps) {
         if (router.crudMiddleware) {
             if (_.isNil(maps)) {
-                return query(router, router.crudMiddleware, crudMiddleware);
+                return query.addQueryRoute(router, router.crudMiddleware, crudMiddleware);
             }
         }
-        return query(router, crudMiddleware, maps);
+        return query.addQueryRoute(router, crudMiddleware, maps);
     };
     router.getById = function(crudMiddleware, maps) {
         if (router.crudMiddleware) {

--- a/src/crud/update-status.js
+++ b/src/crud/update-status.js
@@ -11,7 +11,14 @@ const boom = require('boom');
 const util = require('util');
 const permissions = require('../permissions');
 
-module.exports = function addUpdateStatusRoute(router, crudMiddleware, maps) {
+module.exports = {
+    addUpdateStatusRoute,
+    getSteps,
+    description,
+    ensureStatusAllowed
+};
+
+function addUpdateStatusRoute(router, crudMiddleware, maps) {
     if (!router.metadata.schemas.core.statuses) {
         throw new Error('No statuses defined in metadata.schemas.core.statuses');
     }
@@ -23,9 +30,7 @@ module.exports = function addUpdateStatusRoute(router, crudMiddleware, maps) {
     }
     if (!router.metadata.schemas.updateStatus) {
         if (router.metadata.schemas.core.updateStatusSchema) {
-            router.metadata.schemas.updateStatus = _.cloneDeep(
-                router.metadata.schemas.core.updateStatusSchema
-            );
+            router.metadata.schemas.updateStatus = _.cloneDeep(router.metadata.schemas.core.updateStatusSchema);
             router.metadata.schemas.updateStatus.$id = router.metadata.schemas.core.$id.replace(
                 '.json',
                 '-updateStatus.json'
@@ -36,13 +41,10 @@ module.exports = function addUpdateStatusRoute(router, crudMiddleware, maps) {
     }
     validator.addSchema(router.metadata.schemas.updateStatus);
     router
-        .put(
-            '/:' + router.metadata.identifierName + '/:newStatusName',
-            getSteps(router, crudMiddleware, maps)
-        )
+        .put('/:' + router.metadata.identifierName + '/:newStatusName', getSteps(router, crudMiddleware, maps))
         .describe(router.metadata.updateStatusDescription || description(router.metadata));
     return router;
-};
+}
 
 function getSteps(router, crudMiddleware, maps) {
     const steps = {

--- a/src/crud/update-status.js
+++ b/src/crud/update-status.js
@@ -30,7 +30,9 @@ function addUpdateStatusRoute(router, crudMiddleware, maps) {
     }
     if (!router.metadata.schemas.updateStatus) {
         if (router.metadata.schemas.core.updateStatusSchema) {
-            router.metadata.schemas.updateStatus = _.cloneDeep(router.metadata.schemas.core.updateStatusSchema);
+            router.metadata.schemas.updateStatus = _.cloneDeep(
+                router.metadata.schemas.core.updateStatusSchema
+            );
             router.metadata.schemas.updateStatus.$id = router.metadata.schemas.core.$id.replace(
                 '.json',
                 '-updateStatus.json'
@@ -41,7 +43,10 @@ function addUpdateStatusRoute(router, crudMiddleware, maps) {
     }
     validator.addSchema(router.metadata.schemas.updateStatus);
     router
-        .put('/:' + router.metadata.identifierName + '/:newStatusName', getSteps(router, crudMiddleware, maps))
+        .put(
+            '/:' + router.metadata.identifierName + '/:newStatusName',
+            getSteps(router, crudMiddleware, maps)
+        )
         .describe(router.metadata.updateStatusDescription || description(router.metadata));
     return router;
 }

--- a/src/crud/update.js
+++ b/src/crud/update.js
@@ -52,12 +52,19 @@ function description(metadata) {
     const correlationIdOptions = config.get('logging').correlationId;
     return {
         security: true,
-        summary: 'Updates ' + metadata.aOrAn + ' ' + metadata.title + ' By ' + _.startCase(metadata.identifierName),
+        summary:
+            'Updates ' +
+                metadata.aOrAn +
+                ' ' +
+                metadata.title +
+                ' By ' +
+                _.startCase(metadata.identifierName),
         tags: [metadata.tag.name],
         parameters: [
             {
                 name: metadata.identifierName,
-                description: 'The field to uniquely identify this ' + metadata.title.toLowerCase() + '.',
+                description:
+                    'The field to uniquely identify this ' + metadata.title.toLowerCase() + '.',
                 required: true,
                 in: 'path',
                 type: 'string'

--- a/src/crud/update.js
+++ b/src/crud/update.js
@@ -11,7 +11,13 @@ const versionInfo = require('../version-info');
 const config = require('nconf');
 const permissions = require('../permissions');
 
-module.exports = function addUpdateRoute(router, crudMiddleware, maps) {
+module.exports = {
+    addUpdateRoute,
+    getSteps,
+    description
+};
+
+function addUpdateRoute(router, crudMiddleware, maps) {
     ensureSchemaSet(router.metadata, schemaName, 'Input');
     filterPropertiesForUpdate(router.metadata.schemas[schemaName]);
     const routeName = '/:' + router.metadata.identifierName;
@@ -22,7 +28,7 @@ module.exports = function addUpdateRoute(router, crudMiddleware, maps) {
     router.patch(routeName, routeAction).describe(_.cloneDeep(routeDescription));
 
     return router;
-};
+}
 
 function getSteps(router, crudMiddleware, maps) {
     const steps = {
@@ -46,19 +52,12 @@ function description(metadata) {
     const correlationIdOptions = config.get('logging').correlationId;
     return {
         security: true,
-        summary:
-            'Updates ' +
-                metadata.aOrAn +
-                ' ' +
-                metadata.title +
-                ' By ' +
-                _.startCase(metadata.identifierName),
+        summary: 'Updates ' + metadata.aOrAn + ' ' + metadata.title + ' By ' + _.startCase(metadata.identifierName),
         tags: [metadata.tag.name],
         parameters: [
             {
                 name: metadata.identifierName,
-                description:
-                    'The field to uniquely identify this ' + metadata.title.toLowerCase() + '.',
+                description: 'The field to uniquely identify this ' + metadata.title.toLowerCase() + '.',
                 required: true,
                 in: 'path',
                 type: 'string'

--- a/test/crud/create.unit.js
+++ b/test/crud/create.unit.js
@@ -1,6 +1,6 @@
 'use strict';
 require('../@util/init.js');
-const addCreateRoute = require('../../src/crud/create');
+const create = require('../../src/crud/create');
 const mockRequest = require('../@util/request-mocking').mockRequest;
 const moment = require('moment');
 const sinon = require('sinon');
@@ -10,7 +10,7 @@ describe('Crud - create', function() {
     describe('setStatusIfApplicable', function() {
         it('Should not set req.body.status if the provided schema has no statuses', function(done) {
             const metadata = buildMetadata();
-            const middleware = addCreateRoute.setStatusIfApplicable(metadata);
+            const middleware = create.setStatusIfApplicable(metadata);
             const reqOptions = {
                 body: {}
             };
@@ -27,7 +27,7 @@ describe('Crud - create', function() {
 
         it('Should set req.body.status to the first status in the schema', function(done) {
             const metadata = buildMetadata([{ name: 'a' }, { name: 'b' }]);
-            const middleware = addCreateRoute.setStatusIfApplicable(metadata);
+            const middleware = create.setStatusIfApplicable(metadata);
             const reqOptions = {
                 body: {}
             };
@@ -42,7 +42,7 @@ describe('Crud - create', function() {
 
         it('Should set req.body.statusDate to now', function(done) {
             const metadata = buildMetadata([{ name: 'a' }]);
-            const middleware = addCreateRoute.setStatusIfApplicable(metadata);
+            const middleware = create.setStatusIfApplicable(metadata);
             const reqOptions = {
                 body: {}
             };
@@ -57,7 +57,7 @@ describe('Crud - create', function() {
 
         it('Should create a status log with one entry', function(done) {
             const metadata = buildMetadata([{ name: 'a' }]);
-            const middleware = addCreateRoute.setStatusIfApplicable(metadata);
+            const middleware = create.setStatusIfApplicable(metadata);
             const reqOptions = {
                 body: {}
             };
@@ -74,7 +74,7 @@ describe('Crud - create', function() {
             done
         ) {
             const metadata = buildMetadata([{ name: 'a' }]);
-            const middleware = addCreateRoute.setStatusIfApplicable(metadata);
+            const middleware = create.setStatusIfApplicable(metadata);
             const reqOptions = {
                 body: {}
             };
@@ -89,7 +89,7 @@ describe('Crud - create', function() {
 
         it('Should create a status log entry with the statusDate set to now', function(done) {
             const metadata = buildMetadata([{ name: 'a' }]);
-            const middleware = addCreateRoute.setStatusIfApplicable(metadata);
+            const middleware = create.setStatusIfApplicable(metadata);
             const reqOptions = {
                 body: {}
             };
@@ -110,7 +110,7 @@ describe('Crud - create', function() {
                     name: 'a'
                 };
                 const metadata = buildMetadata([statusToSet]);
-                const middleware = addCreateRoute.setStatusIfApplicable(metadata);
+                const middleware = create.setStatusIfApplicable(metadata);
                 const reqOptions = {
                     body: {}
                 };
@@ -130,7 +130,7 @@ describe('Crud - create', function() {
                     initialData: {}
                 };
                 const metadata = buildMetadata([statusToSet]);
-                const middleware = addCreateRoute.setStatusIfApplicable(metadata);
+                const middleware = create.setStatusIfApplicable(metadata);
                 const reqOptions = {
                     body: {}
                 };
@@ -150,7 +150,7 @@ describe('Crud - create', function() {
                     initialData: {}
                 };
                 const metadata = buildMetadata([statusToSet]);
-                const middleware = addCreateRoute.setStatusIfApplicable(metadata);
+                const middleware = create.setStatusIfApplicable(metadata);
                 const reqOptions = {
                     body: {}
                 };
@@ -161,7 +161,7 @@ describe('Crud - create', function() {
                         name: 'bob'
                     }
                 };
-                const stub = sinon.stub(addCreateRoute, 'getData');
+                const stub = sinon.stub(create, 'getData');
                 stub.returns(stubbedData);
                 mockRequest(middleware, reqOptions, null, next);
 
@@ -178,12 +178,12 @@ describe('Crud - create', function() {
 
     describe('getData', function() {
         it('Should not exist if rules was falsy', function() {
-            const data = addCreateRoute.getData(null, {});
+            const data = create.getData(null, {});
             expect(data).to.not.be.ok();
         });
 
         it('Should be an empty object if rules was an empty object', function() {
-            const data = addCreateRoute.getData({}, {});
+            const data = create.getData({}, {});
             expect(data).to.be.ok();
             expect(Object.keys(data)).to.have.lengthOf(0);
         });
@@ -199,7 +199,7 @@ describe('Crud - create', function() {
                     object: {}
                 }
             };
-            const data = addCreateRoute.getData(rules, req);
+            const data = create.getData(rules, req);
             expect(data).to.deep.equal(rules.static);
         });
 
@@ -211,9 +211,9 @@ describe('Crud - create', function() {
             const stubbedData = {
                 bob: true
             };
-            const stub = sinon.stub(addCreateRoute, 'getFromReqObject');
+            const stub = sinon.stub(create, 'getFromReqObject');
             stub.returns(stubbedData);
-            const data = addCreateRoute.getData(rules, req);
+            const data = create.getData(rules, req);
             stub.restore();
             expect(data.bob).to.equal(true);
         });
@@ -235,9 +235,9 @@ describe('Crud - create', function() {
             const stubbedData = {
                 bob: true
             };
-            const stub = sinon.stub(addCreateRoute, 'getFromReqObject');
+            const stub = sinon.stub(create, 'getFromReqObject');
             stub.returns(stubbedData);
-            const data = addCreateRoute.getData(rules, req);
+            const data = create.getData(rules, req);
             stub.restore();
             expect(data.bob).to.equal(true);
             expect(data.number).to.equal(rules.static.number);
@@ -271,9 +271,9 @@ describe('Crud - create', function() {
                     betterSubObject: {}
                 }
             };
-            const stub = sinon.stub(addCreateRoute, 'getFromReqObject');
+            const stub = sinon.stub(create, 'getFromReqObject');
             stub.returns(stubbedData);
-            const data = addCreateRoute.getData(rules, req);
+            const data = create.getData(rules, req);
             stub.restore();
             expect(data.bob).to.equal(true);
             expect(data.number).to.equal(stubbedData.number);
@@ -293,7 +293,7 @@ describe('Crud - create', function() {
             const map = {
                 answer: 'a'
             };
-            const data = addCreateRoute.getFromReqObject(map, req, 0, undefined, ['a']);
+            const data = create.getFromReqObject(map, req, 0, undefined, ['a']);
             expect(data.answer).to.equal('b');
         });
 
@@ -306,7 +306,7 @@ describe('Crud - create', function() {
             const map = {
                 answer: 'a.b'
             };
-            const data = addCreateRoute.getFromReqObject(map, req, 0, undefined, ['a']);
+            const data = create.getFromReqObject(map, req, 0, undefined, ['a']);
             expect(data.answer).to.equal('c');
         });
 
@@ -319,7 +319,7 @@ describe('Crud - create', function() {
                     answer: 'a'
                 }
             };
-            const data = addCreateRoute.getFromReqObject(map, req, 0, undefined, ['a']);
+            const data = create.getFromReqObject(map, req, 0, undefined, ['a']);
             expect(data.nested.answer).to.equal('b');
         });
 
@@ -334,7 +334,7 @@ describe('Crud - create', function() {
                     answer: 'a.b'
                 }
             };
-            const data = addCreateRoute.getFromReqObject(map, req, 0, undefined, ['a']);
+            const data = create.getFromReqObject(map, req, 0, undefined, ['a']);
             expect(data.nested.answer).to.equal('c');
         });
 
@@ -349,7 +349,7 @@ describe('Crud - create', function() {
             };
             map.nested.answer = map;
             expect(function() {
-                addCreateRoute.getFromReqObject(map, req);
+                create.getFromReqObject(map, req);
             }).to.throw(/circular reference/i);
         });
 
@@ -363,7 +363,7 @@ describe('Crud - create', function() {
                 answer: 1
             };
             expect(function() {
-                addCreateRoute.getFromReqObject(map, req);
+                create.getFromReqObject(map, req);
             }).to.throw(notAString);
         });
 
@@ -375,7 +375,7 @@ describe('Crud - create', function() {
                 answer: true
             };
             expect(function() {
-                addCreateRoute.getFromReqObject(map, req);
+                create.getFromReqObject(map, req);
             }).to.throw(notAString);
         });
 
@@ -386,7 +386,7 @@ describe('Crud - create', function() {
             const map = {
                 answer: {}
             };
-            const data = addCreateRoute.getFromReqObject(map, req);
+            const data = create.getFromReqObject(map, req);
             expect(data.answer).to.deep.equal({});
         });
 
@@ -398,7 +398,7 @@ describe('Crud - create', function() {
                 answer: null
             };
             expect(function() {
-                addCreateRoute.getFromReqObject(map, req);
+                create.getFromReqObject(map, req);
             }).to.throw(notAString);
         });
 
@@ -410,7 +410,7 @@ describe('Crud - create', function() {
                 answer: undefined
             };
             expect(function() {
-                addCreateRoute.getFromReqObject(map, req);
+                create.getFromReqObject(map, req);
             }).to.throw(notAString);
         });
 
@@ -421,7 +421,7 @@ describe('Crud - create', function() {
             const map = {
                 answer: ['c', 'd']
             };
-            const result = addCreateRoute.getFromReqObject(map, req, 0, undefined, ['c']);
+            const result = create.getFromReqObject(map, req, 0, undefined, ['c']);
             expect(result.answer).to.equal('d');
         });
 
@@ -432,7 +432,7 @@ describe('Crud - create', function() {
             const map = {
                 answer: ['a']
             };
-            const result = addCreateRoute.getFromReqObject(map, req, 0, undefined, ['a']);
+            const result = create.getFromReqObject(map, req, 0, undefined, ['a']);
             expect(result.answer).to.equal('b');
         });
 
@@ -444,7 +444,7 @@ describe('Crud - create', function() {
                 answer: [1]
             };
             expect(function() {
-                addCreateRoute.getFromReqObject(map, req);
+                create.getFromReqObject(map, req);
             }).to.throw(notAString);
         });
 
@@ -456,7 +456,7 @@ describe('Crud - create', function() {
                 answer: []
             };
             expect(function() {
-                addCreateRoute.getFromReqObject(map, req);
+                create.getFromReqObject(map, req);
             }).to.throw(notAString);
         });
 
@@ -468,7 +468,7 @@ describe('Crud - create', function() {
                 answer: ['a', 'a', 'a']
             };
             expect(function() {
-                addCreateRoute.getFromReqObject(map, req);
+                create.getFromReqObject(map, req);
             }).to.throw(/too many items in array/i);
         });
 
@@ -484,7 +484,7 @@ describe('Crud - create', function() {
             };
             const disallowedSuffixList = ['.b'];
             expect(function() {
-                addCreateRoute.getFromReqObject(map, req, 0, disallowedSuffixList);
+                create.getFromReqObject(map, req, 0, disallowedSuffixList);
             }).to.throw(invalidSuffix);
         });
 
@@ -498,7 +498,7 @@ describe('Crud - create', function() {
                 answer: 'a.password'
             };
             expect(function() {
-                addCreateRoute.getFromReqObject(map, req);
+                create.getFromReqObject(map, req);
             }).to.throw(invalidSuffix);
         });
 
@@ -514,7 +514,7 @@ describe('Crud - create', function() {
             };
             const allowedPrefixList = [];
             expect(function() {
-                addCreateRoute.getFromReqObject(map, req, 0, undefined, allowedPrefixList);
+                create.getFromReqObject(map, req, 0, undefined, allowedPrefixList);
             }).to.throw(invalidPrefix);
         });
 
@@ -528,7 +528,7 @@ describe('Crud - create', function() {
                 answer: 'body.password'
             };
             expect(function() {
-                addCreateRoute.getFromReqObject(map, req);
+                create.getFromReqObject(map, req);
             }).to.throw(invalidSuffix);
         });
     });


### PR DESCRIPTION
Refactoring generic CRUD functions to export all their functions as properties on an object rather than tacked on to the primary function. This will allow for easier unit testing